### PR TITLE
Add prepare script to support Git-based installation builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "build:css": "postcss src/index.css -o dist/styles.css",
         "build:ts": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
         "build": "npm run build:css && npm run build:ts",
+        "prepare": "npm run build",
         "typecheck": "tsc -p tsconfig.json",
         "lint": "eslint \"src/**/*.{ts,tsx,css}\"",
         "prepublishOnly": "npm run build",
@@ -55,10 +56,10 @@
         "tailwindcss": "^4.1.17",
         "tsc-alias": "^1.8.16",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.52.0"
+        "typescript-eslint": "^8.52.0",
+        "@tailwindcss/cli": "^4.1.17"
     },
     "dependencies": {
-        "@tailwindcss/cli": "^4.1.17",
         "class-variance-authority": "^0.7.1"
     }
 }


### PR DESCRIPTION
## Description

This PR:
- Add 'prepare' script so the package builds automatically when installed from Git (fixes TS2307 module resolution errors in consuming apps)
- Move @tailwindcss/cli from dependencies to devDependencies since it is only used by the playground build and should not be shipped as a transitive runtime dependency

## Related Issues
- #91 

## Checklist
Please ensure that your PR meets the following criteria by checking each item:

- [x] I have tested my changes thoroughly and they do not introduce new issues.
- [x] My code follows our coding style and conventions.
- [x] I have added appropriate documentation or updated existing documentation to reflect the changes.
- [x] All new and existing tests have passed successfully.
- [x] I have added necessary comments to my code for clarity, especially in complex sections.
- [x] I have considered and addressed potential edge cases or error scenarios.
- [x] The code is ready for review and can be merged into the main or dev branch.